### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
             docker_image.txt
             release_version.txt
       - name: Build and publish to registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           APP_VERSION: ${{ env.RELEASE_VERSION }}
           RELEASE_DATE: $(date +\"%Y/%m/%d\")


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore